### PR TITLE
EXP: try running CI with pytest 8.0

### DIFF
--- a/.github/workflows/ci_workflows.yml
+++ b/.github/workflows/ci_workflows.yml
@@ -8,6 +8,7 @@ on:
     tags:
     - '*'
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Seeing some odd failures in CI that I suspect are just due to the switch to pytest 8.0, just released.